### PR TITLE
params on function get_timesheet_approvals

### DIFF
--- a/tempoapiclient/client.py
+++ b/tempoapiclient/client.py
@@ -250,7 +250,7 @@ class Tempo(RestAPIClient):
             url += f"/user/{userId}"
         elif teamId:
             url += f"/team/{teamId}"
-        return self.get(url, params)
+        return self.get(url, params=params)
 
 # User Schedule
 


### PR DESCRIPTION
On return of the function get_timesheet_approvals missing params=params (was only params).
This returns on "get" function params as "None"