### PR TITLE
Add update and delete worklogs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /tempo_api_python_client.egg-info
 /dist
 /build
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ You need an API token for communicating with tempo REST APIs.
     for i in worklogs:
         print(i)
 
+There are also functions to retrieve `user` and `team`-specific worklogs.
+
 
 #### Create Worklog
 
@@ -82,8 +84,6 @@ You need an API token for communicating with tempo REST APIs.
 #### Delete Worklog
 
     delete_response = tempo.delete_worklog(<worklog_id>)
-
-There are also functions to retrieve `user` and `team`-specific worklogs.
 
 
 ## Code Format

--- a/README.md
+++ b/README.md
@@ -68,6 +68,21 @@ You need an API token for communicating with tempo REST APIs.
         startTime="17:00:00"
     )
 
+#### Update Worklog
+
+    logged_worklog = tempo.update_worklog(
+        id="<id_of_the_worklog_to_be_updated>"  # required
+        accountId="<your_jira_account_id>",     # required
+        dateFrom="2019-11-11",                  # required
+        timeSpentSeconds=3600,                  # required
+        description="Something",                # optional
+        startTime="17:00:00"                    # optional
+    )
+
+#### Delete Worklog
+
+    delete_response = tempo.delete_worklog(<worklog_id>)
+
 There are also functions to retrieve `user` and `team`-specific worklogs.
 
 

--- a/tempoapiclient/client_v4.py
+++ b/tempoapiclient/client_v4.py
@@ -640,8 +640,50 @@ class Tempo(RestAPIClient):
         
         return self.post(url, data=data)
 
+    def update_worklog(self, id, accountId, dateFrom, timeSpentSeconds, billableSeconds=None, description=None,
+                       remainingEstimateSeconds=None, startTime=None):
+        """
+        Updates an existing Worklog using the provided input and returns the updated Worklog.
+        :param id: The ID of the Worklog to be updated
+        :param accountId: The Author account ID of the user author
+        :param dateFrom: The start date of the Worklog
+        :param timeSpentSeconds: The total amount of time spent in seconds
+        :param billableSeconds: The amount of seconds billable
+        :param description: The description of the Worklog
+        :param remainingEstimateSeconds: The total amount of estimated remaining seconds
+        :param startTime: The start time of the Worklog
 
+        See https://apidocs.tempo.io/#tag/Worklogs/operation/updateWorklog
+        """
 
+        url = f"/worklogs/{id}"
+        
+        data = {
+            "authorAccountId": str(accountId),
+            "startDate": self._resolve_date(dateFrom).isoformat(),
+            "timeSpentSeconds": int(timeSpentSeconds),
+        }
+
+        if billableSeconds:
+            data["billableSeconds"] = int(billableSeconds)
+        if description:
+            data["description"] = str(description)
+        if remainingEstimateSeconds:
+            data["remainingEstimateSeconds"] = int(remainingEstimateSeconds)
+        if startTime:
+            data["startTime"] = self._resolve_time(startTime).isoformat()
+        
+        return self.put(url, data=data)
+
+    def delete_worklog(self, id):
+        """
+        Deletes a Worklog
+        :param id: The ID of the Worklog to be deleted
+
+        See https://apidocs.tempo.io/#tag/Worklogs/operation/deleteWorklog
+        """
+        url = f"/worklogs/{id}"
+        return self.delete(url)
 
 # Customer
 

--- a/tests/test_client_v4.py
+++ b/tests/test_client_v4.py
@@ -1,10 +1,13 @@
 from unittest import TestCase, main
+import logging
 import os
 import sys
 
 from tempoapiclient.client_v4 import Tempo
 
 # please set TEMPO_AUTH_TOKEN to environment before running this test
+
+log = logging.getLogger()
 
 
 class TestClient(TestCase):
@@ -13,6 +16,10 @@ class TestClient(TestCase):
         self.tempo = Tempo(auth_token=os.environ.get('TEMPO_AUTH_TOKEN'))
         self.dateFrom = "2020-09-01"
         self.dateTo = "2020-10-01"
+
+        self.accountId = os.environ.get('TEMPO_ACCOUNT_ID')
+        self.issueId = os.environ.get('TEMPO_ISSUE_ID')
+
     
     def test_client_creation(self):
         self.assertTrue(isinstance(self.tempo, Tempo))
@@ -58,6 +65,135 @@ class TestClient(TestCase):
         self.assertIsInstance(team_members, list)
         self.assertIsInstance(team_members[0], dict)
         self.assertIsInstance(team_members[0]['member'], dict)
+
+    @staticmethod
+    def _compare_worklog_to_parameters(worklog, parameters):
+        """
+        Compares worklog values to parameters of create_worklog and update_worklog methods
+
+        :param worklog: Worklog returned from Tempo
+        :param parameters: parameters for create_worklog and update_worklog methods
+        """
+        return (
+            all((
+                worklog[keys[0]] == parameters[keys[1]] for keys in (
+                    ("startDate", "dateFrom", ),
+                    ("timeSpentSeconds", "timeSpentSeconds", ),
+                    ("description", "description", ),
+                )
+            ))
+            and
+            worklog["author"]["accountId"] == parameters["accountId"]
+        )
+
+    @staticmethod
+    def _compare_worklogs(worklog_a, worklog_b):
+        """
+        Compares values of two worklogs together
+        """
+        return all((
+            worklog_a[key] == worklog_b[key] for key in (
+                "tempoWorklogId", "author", "issue", "startDate",
+                "timeSpentSeconds", "description", )
+        ))
+
+    def test_worklog_cycle(self):
+        """
+        Tests worklog creation, read, update and deletion
+
+        This test creates a new worklog, reads it, updated it and finally deletes it.
+        Thus, you may not want to run this test in a production environment.
+
+        The following environments are required in order to run this test:
+        * TEMPO_ACCOUNT_ID: the Jira account id to be set as the author of the worklog
+        * TEMPO_ISSUE_ID: the Jira issue id the Worklog is created
+        """
+
+        # Test worklog creation (and read)
+        create_parameters = {
+            "accountId": self.accountId,
+            "issueId": self.issueId,
+            "dateFrom": self.dateFrom,
+            "timeSpentSeconds": 7200,
+            "description": "TEST worklog",
+        }
+
+        created_worklog = self.tempo.create_worklog(**create_parameters)
+
+        log.debug("created_worklog: %r", created_worklog)
+        print(f"test_worklog_cycle: created worklog with ID: "
+              f"{created_worklog.get('tempoWorklogId')}")
+
+        self.assertIsInstance(created_worklog, dict)
+        self.assertEqual(created_worklog["issue"]["id"], int(create_parameters["issueId"]))
+        self.assertTrue(self._compare_worklog_to_parameters(created_worklog,
+                                                            create_parameters))
+
+        read_created_worklog = self.tempo.get_worklogs(
+            self.dateFrom, self.dateFrom,
+            worklogId=created_worklog.get('tempoWorklogId')
+        )
+        log.debug("read_created_worklog: %r", read_created_worklog)
+
+        self.assertIsInstance(read_created_worklog, dict)
+        self.assertTrue(self._compare_worklogs(created_worklog, read_created_worklog))
+
+        # Test worklog update (and read)
+        update_parameters = {
+            "id": created_worklog["tempoWorklogId"],
+            "accountId": self.accountId,
+            "dateFrom": self.dateFrom,
+            "timeSpentSeconds": 10800,
+            "description": "Updated TEST worklog",
+        }
+
+        updated_worklog = self.tempo.update_worklog(**update_parameters)
+
+        log.debug("updated_worklog: %r", updated_worklog)
+        print(f"test_worklog_cycle: updated worklog with ID: "
+              f"{updated_worklog.get('tempoWorklogId')}")
+
+        self.assertIsInstance(updated_worklog, dict)
+        self.assertEqual(created_worklog["tempoWorklogId"], updated_worklog["tempoWorklogId"])
+        self.assertTrue(self._compare_worklog_to_parameters(updated_worklog,
+                                                            update_parameters))
+
+        read_updated_worklog = self.tempo.get_worklogs(
+            self.dateFrom, self.dateFrom,
+            worklogId=created_worklog.get('tempoWorklogId')
+        )
+        log.debug("read_updated_worklog: %r", read_updated_worklog)
+
+        self.assertIsInstance(read_updated_worklog, dict)
+        self.assertTrue(self._compare_worklogs(updated_worklog, read_updated_worklog))
+
+        # Test worklog deletion
+        deleted_worklog = self.tempo.delete_worklog(created_worklog['tempoWorklogId'])
+
+        log.debug("deleted_worklog: %r", deleted_worklog)
+
+        self.assertIsInstance(deleted_worklog, dict)
+        self.assertFalse(deleted_worklog)
+
+        # The worklog should not exist anymore
+        with self.assertRaises(SystemExit) as exc:
+            read_deleted_worklog = self.tempo.get_worklogs(
+                self.dateFrom, self.dateFrom,
+                worklogId=created_worklog.get('tempoWorklogId')
+            )
+
+        print(f"test_worklog_cycle: deleted worklog with ID: {created_worklog.get('tempoWorklogId')}")
+
+    def test_get_worklogs(self):
+        """
+        Tests reading worklogs
+        """
+        worklogs = self.tempo.get_worklogs(self.dateFrom, self.dateTo)
+
+        log.debug("worklogs: %r", worklogs)
+        print(f"get_worklogs: {len(worklogs)}")
+
+        self.assertIsInstance(worklogs, list)
 
     #def test_get_team_memberships(self):
         # l = self.tempo.get_team_memberships(membershipId=)


### PR DESCRIPTION
Added the following new methods:

- `tempoapiclient.client_v4.Tempo.update_worklog()`
- `tempoapiclient.client_v4.Tempo.delete_worklog()`

and the following tests:

- `test_client_v4.TestClient.test_worklog_cycle()` – simple test for worklog creation, read, update and deletion
- `test_client_v4.TestClient.test_get_worklogs()` – even simpler test for worklog read.

Also added brief usage instructions.

Both of the commits have been signed by me.

I have tested the new methods in a live environment and they seem to work, so I would appreciate if you could merge this branch to upstream.