### PR TITLE
feat: extend `worklog` function with `attributes` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ There are also functions to retrieve `user` and `team`-specific worklogs.
         timeSpentSeconds=3600,
         description="Something",
         startTime="17:00:00"
+        attributes=[{_WorkType_: "Development"}]
     )
 
 #### Update Worklog

--- a/tempoapiclient/client_v4.py
+++ b/tempoapiclient/client_v4.py
@@ -606,7 +606,7 @@ class Tempo(RestAPIClient):
         return self.post(url, params=params, data=data)
 
     def create_worklog(self, accountId, issueId, dateFrom, timeSpentSeconds, billableSeconds=None, description=None,
-                       remainingEstimateSeconds=None, startTime=None):
+                       remainingEstimateSeconds=None, startTime=None, attributes=None):
         """
         Creates a new Worklog using the provided input and returns the newly created Worklog.
         :param accountId:
@@ -617,6 +617,7 @@ class Tempo(RestAPIClient):
         :param description:
         :param remainingEstimateSeconds:
         :param startTime:
+        :param attributes:
         """
 
         url = f"/worklogs"
@@ -625,7 +626,8 @@ class Tempo(RestAPIClient):
             "authorAccountId": str(accountId),
             "issueId": int(issueId),
             "startDate": self._resolve_date(dateFrom).isoformat(),
-            "timeSpentSeconds": int(timeSpentSeconds)
+            "timeSpentSeconds": int(timeSpentSeconds),
+            "attributes": attributes
         }
 
         if billableSeconds:


### PR DESCRIPTION
Hi Stanislav,

Great tool! I noticed that a parameter was missing in the worklog function, so I’ve created a pull request to address it. I’d be glad if it could be merged into the main branch.

The update aligns with the API specifications, which you can find here: https://apidocs.tempo.io/#tag/Worklogs/operation/createWorklog.

In my case, the parameter is mandatory, as it’s required by my Tempo admin.

If you have any feedback regarding the code style, please let me know, or feel free to make any adjustments as you see fit.

Best regards,
Tonda